### PR TITLE
Add PubMed API rate limiting and XML parsing fixes

### DIFF
--- a/PubMed_API_0.1.py
+++ b/PubMed_API_0.1.py
@@ -1,27 +1,32 @@
 import requests
 import csv
+import time
+import xml.etree.ElementTree as ET
 
 # lista de PubMed artículos
 pmids = ["16957370", "25471818", "34370220", "27807838", "21342132"]
 
-#creación del documento:
+# creación del documento:
 with open("papers.csv", "w", newline='', encoding="utf-8") as csvfile:
     writer = csv.writer(csvfile)
     writer.writerow(["PMID", "Title", "Abstract"])
 
     for pmid in pmids:
-        url = f"https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
+        url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
         params = {
             "db": "pubmed",
             "id": pmid,
             "retmode": "xml",
-            "retstart": 0,
-            "retmax": 100,
-            "retsort": "relevance",
-            "term": "PubMed",
         }
-        response = requests.get(url, params=params)
-        xml = response.text
-        root = ET.fromstring(xml)
-
-        writer.writerow([pmid, root.find("title").text, root.find("abstract").text])
+        try:
+            response = requests.get(url, params=params, headers={
+                "User-Agent": "Proyecto-Terminal (your_email@example.com)"
+            })
+            response.raise_for_status()
+            root = ET.fromstring(response.text)
+            title = root.findtext(".//ArticleTitle", default="")
+            abstract = root.findtext(".//Abstract/AbstractText", default="")
+            writer.writerow([pmid, title, abstract])
+        except Exception as e:
+            print(f"Error retrieving PMID {pmid}: {e}")
+        time.sleep(0.34)


### PR DESCRIPTION
## Summary
- Import ElementTree and time for parsing and rate limiting
- Fetch PubMed titles and abstracts with error handling and User-Agent
- Pause between requests to stay under three per second

## Testing
- ⚠️ `python PubMed_API_0.1.py` *(missing `requests` library)*
- ⚠️ `pip install requests` *(proxy prevented install)*

------
https://chatgpt.com/codex/tasks/task_e_68b69e8a2878832b9ad9907bfe5ff470