### PR TITLE
Add argparse for configurable PubMed queries

### DIFF
--- a/PubMed_API_0.1.py
+++ b/PubMed_API_0.1.py
@@ -1,29 +1,36 @@
 import requests
 import csv
 import time
+import argparse
 import xml.etree.ElementTree as ET
-
-# término de búsqueda para PubMed
-search_term = "microRNA"
 
 search_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/esearch.fcgi"
 fetch_url = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi"
 headers = {"User-Agent": "Proyecto-Terminal (eduardo_bio12@outlook.com)"}
+
+parser = argparse.ArgumentParser(description="Download PubMed papers to CSV")
+parser.add_argument("--search_term", default="microRNA", help="Term to search for in PubMed")
+parser.add_argument("--max_results", type=int, default=5, help="Maximum number of results to fetch")
+parser.add_argument("--start_year", type=int, default=None, help="Start year for articles (optional)")
+args = parser.parse_args()
 
 # obtener PMIDs a partir del término de búsqueda
 pmids = []
 try:
     search_params = {
         "db": "pubmed",
-        "term": search_term,
+        "term": args.search_term,
         "retmode": "json",
-        "retmax": 5,
+        "retmax": args.max_results,
     }
+    if args.start_year:
+        search_params["mindate"] = args.start_year
+        search_params["datetype"] = "pdat"
     search_response = requests.get(search_url, params=search_params, headers=headers)
     search_response.raise_for_status()
     pmids = search_response.json().get("esearchresult", {}).get("idlist", [])
 except Exception as e:
-    print(f"Error searching term '{search_term}': {e}")
+    print(f"Error searching term '{args.search_term}': {e}")
 
 # creación del documento:
 with open("papers.csv", "w", newline='', encoding="utf-8") as csvfile:


### PR DESCRIPTION
## Summary
- enable command line arguments for PubMed term, result count, and start year
- build search parameters from parsed args

## Testing
- ⚠️ `python PubMed_API_0.1.py --help` *(missing dependency: requests)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b2b61f30832baf2c4c79fe62199e