### PR TITLE
Use run_query in CLI

### DIFF
--- a/interactive_cli.py
+++ b/interactive_cli.py
@@ -128,7 +128,7 @@ def main():
     )
     pubmed_api = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(pubmed_api)
-    pubmed_api.main(
+    pubmed_api.run_query(
         terms=terms,
         operator=operator,
         sort=sort,


### PR DESCRIPTION
## Summary
- Replace `main` invocation with `run_query` in the interactive CLI

## Testing
- `python -m py_compile interactive_cli.py`


------
https://chatgpt.com/codex/tasks/task_e_68b6dc24a54c832b93bac8f9241fdd0a