### PR TITLE
Add local PubMed search CLI with ranking and analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,32 @@ export NCBI_API_KEY="your_api_key_here"
 ```
 
 This increases the request rate limits when running `PubMed_API_0.1.py`.
+
+## CLI de búsqueda local
+
+Instala dependencias y ejecuta los comandos desde la raíz del repositorio.
+
+### Ejemplos
+
+```bash
+# Búsqueda principal (AND por default), título+abstract, año >= 2020
+python pt_search.py search --query "microRNA; IBD" --year-min 2020 --k 30
+
+# Operador OR y filtro por journal
+python pt_search.py search --query "microRNA; celiac" --op OR --journal-include "Gut; Scientific Reports"
+
+# Excluir términos
+python pt_search.py search --query "microRNA; fibrosis" --exclude "exosome"
+
+# Solo en título y con exportación
+python pt_search.py search --query "TGF-beta" --fields ti --export-base fibrosis_tgf
+
+# Facetas por journal
+python pt_search.py facets --by journal
+
+# Gráfica por año del corpus completo
+python pt_search.py plot-yearly
+
+# Red de coautores sobre una búsqueda
+python pt_search.py coauthors --query "microRNA; IBD" --year-min 2020
+```

--- a/pt_search.py
+++ b/pt_search.py
@@ -1,0 +1,403 @@
+#!/usr/bin/env python3
+import argparse
+import json
+import os
+import re
+from collections import defaultdict
+from typing import List, Dict, Any
+
+import numpy as np
+import pandas as pd
+from sklearn.feature_extraction.text import TfidfVectorizer
+from sklearn.metrics.pairwise import cosine_similarity
+import matplotlib.pyplot as plt
+import networkx as nx
+
+from text_utils import normalize_text, tokenize, expand_query_terms, DOMAIN_KEYWORDS
+
+
+# ----------------------------- Data loading -----------------------------
+
+def load_corpus(jsonl_path: str = "papers.jsonl", csv_path: str = "papers.csv") -> pd.DataFrame:
+    records: List[Dict[str, Any]] = []
+    if os.path.exists(jsonl_path):
+        with open(jsonl_path, "r", encoding="utf-8") as f:
+            for line in f:
+                try:
+                    records.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    elif os.path.exists(csv_path):
+        print("Warning: papers.jsonl not found, using CSV")
+        df_csv = pd.read_csv(csv_path)
+        records = df_csv.to_dict(orient="records")
+    else:
+        raise FileNotFoundError("No corpus found")
+    if not records:
+        raise ValueError("Corpus is empty")
+    df = pd.DataFrame(records).drop_duplicates("PMID", keep="last")
+    df.reset_index(drop=True, inplace=True)
+    df["Year"] = pd.to_numeric(df.get("Year"), errors="coerce").astype("Int64")
+    df["Title"] = df["Title"].apply(normalize_text)
+    df["Abstract"] = df["Abstract"].apply(normalize_text)
+    df["Authors"] = df["Authors"].fillna("").apply(normalize_text)
+    df["Authors_list"] = df["Authors"].apply(lambda x: [a.strip() for a in x.split(";") if a.strip()])
+    df["Journal"] = df["Journal"].fillna("").apply(normalize_text)
+    df["DOI"] = df.get("DOI", "").fillna("").apply(normalize_text)
+    df["citation_apa"] = df.get("citation_apa", "").fillna("")
+    df["Abstract_len"] = df["Abstract"].apply(len)
+    return df
+
+
+# ---------------------------- Index building ----------------------------
+
+class SearchEngine:
+    def __init__(self, df: pd.DataFrame) -> None:
+        self.df = df
+        self.vectorizer_ti = TfidfVectorizer(ngram_range=(1, 2))
+        self.vectorizer_ab = TfidfVectorizer(ngram_range=(1, 2))
+        self.tfidf_ti = self.vectorizer_ti.fit_transform(df["Title"].fillna(""))
+        self.tfidf_ab = self.vectorizer_ab.fit_transform(df["Abstract"].fillna(""))
+        self.inv_ti: Dict[str, set] = defaultdict(set)
+        self.inv_ab: Dict[str, set] = defaultdict(set)
+        self.sentences: Dict[str, List[List[str]]] = {}
+        self.id_to_pos: Dict[str, int] = {}
+        for idx, row in df.iterrows():
+            pmid = row["PMID"]
+            self.id_to_pos[pmid] = idx
+            for tok in tokenize(row["Title"]):
+                self.inv_ti[tok].add(pmid)
+            for tok in tokenize(row["Abstract"]):
+                self.inv_ab[tok].add(pmid)
+            self.sentences[pmid] = [tokenize(s) for s in re.split(r"[\.\!?]", row["Abstract"]) if s.strip()]
+
+    # -------- candidate docs --------
+    def _candidate_pmids(self, query_groups: List[List[str]], op: str, fields: str) -> set:
+        if not query_groups:
+            return set(self.df["PMID"])
+        def index_for(field: str):
+            if field == "ti":
+                return self.inv_ti
+            if field == "ab":
+                return self.inv_ab
+            comb = defaultdict(set)
+            for k, v in self.inv_ti.items():
+                comb[k].update(v)
+            for k, v in self.inv_ab.items():
+                comb[k].update(v)
+            return comb
+        index = index_for(fields)
+        sets = []
+        for group in query_groups:
+            group_set = set()
+            for term in group:
+                group_set.update(index.get(term, set()))
+            sets.append(group_set)
+        all_pmids = set(self.df["PMID"])
+        if op == "AND":
+            cand = all_pmids
+            for s in sets:
+                cand &= s
+            return cand
+        if op == "OR":
+            cand = set()
+            for s in sets:
+                cand.update(s)
+            return cand
+        if op == "NOT":
+            union = set()
+            for s in sets:
+                union.update(s)
+            return all_pmids - union
+        return all_pmids
+
+    # -------- filters --------
+    def _apply_filters(self, pmids: set, year_min: int, year_max: int, journal_inc: List[str],
+                        journal_exc: List[str], author: str, has_doi: bool,
+                        exclude_terms: List[str], fields: str) -> set:
+        df = self.df.set_index("PMID")
+        res = []
+        for pmid in pmids:
+            row = df.loc[pmid]
+            year = row["Year"] if pd.notna(row["Year"]) else None
+            if year is not None and year < year_min:
+                continue
+            if year_max is not None and year is not None and year > year_max:
+                continue
+            journal = row["Journal"].lower()
+            if journal_inc and not any(j.lower() in journal for j in journal_inc):
+                continue
+            if journal_exc and any(j.lower() in journal for j in journal_exc):
+                continue
+            if author and author.lower() not in row["Authors"].lower():
+                continue
+            if has_doi and not row["DOI"]:
+                continue
+            text_fields = []
+            if fields in ("ti", "tiab"):
+                text_fields.append(row["Title"])
+            if fields in ("ab", "tiab"):
+                text_fields.append(row["Abstract"])
+            content = " ".join(text_fields).lower()
+            if any(t.lower() in content for t in exclude_terms):
+                continue
+            res.append(pmid)
+        return set(res)
+
+    # -------- boosts --------
+    def _proximity(self, pmid: str, terms: List[str]) -> bool:
+        sentences = self.sentences.get(pmid, [])
+        for sent in sentences:
+            if sum(1 for t in terms if t in sent) >= 2:
+                return True
+        return False
+
+    def _domain_boost(self, abstract: str) -> float:
+        text = abstract.lower()
+        count = sum(1 for kw in DOMAIN_KEYWORDS if kw in text)
+        return min(0.2, 0.1 * count)
+
+    # -------- search --------
+    def search(self, query: List[str], op: str = "AND", fields: str = "tiab", year_min: int = 2020,
+               year_max: int | None = None, journal_inc: List[str] | None = None,
+               journal_exc: List[str] | None = None, author: str | None = None,
+               has_doi: bool = False, exclude_terms: List[str] | None = None,
+               k: int = 30) -> List[Dict[str, Any]]:
+        journal_inc = journal_inc or []
+        journal_exc = journal_exc or []
+        exclude_terms = exclude_terms or []
+        groups = expand_query_terms(query)
+        pmids = self._candidate_pmids(groups, op, fields)
+        pmids = self._apply_filters(pmids, year_min, year_max, journal_inc, journal_exc,
+                                    author or "", has_doi, exclude_terms, fields)
+        if not pmids:
+            return []
+        df = self.df[self.df["PMID"].isin(pmids)].copy()
+        positions = [self.id_to_pos[p] for p in df["PMID"]]
+        q_text = " ".join([t for g in groups for t in g])
+        cos_ti = np.zeros(len(df))
+        cos_ab = np.zeros(len(df))
+        if fields in ("ti", "tiab"):
+            q_ti = self.vectorizer_ti.transform([q_text])
+            cos_ti = cosine_similarity(q_ti, self.tfidf_ti[positions]).flatten()
+        if fields in ("ab", "tiab"):
+            q_ab = self.vectorizer_ab.transform([q_text])
+            cos_ab = cosine_similarity(q_ab, self.tfidf_ab[positions]).flatten()
+        base_scores = 1.2 * cos_ti + 0.8 * cos_ab
+        flat_terms = [t for g in groups for t in g]
+        results = []
+        df = df.reset_index(drop=True)
+        for i, row in df.iterrows():
+            pmid = row["PMID"]
+            score = base_scores[i]
+            expl = []
+            ti_tokens = tokenize(row["Title"])
+            ab_tokens = tokenize(row["Abstract"])
+            matched = sorted({t for t in flat_terms if t in ti_tokens or t in ab_tokens})
+            if any(t in ti_tokens for t in flat_terms):
+                score += 0.2
+                expl.append("title")
+            year = row["Year"] if pd.notna(row["Year"]) else None
+            if year is not None:
+                if year <= 2020:
+                    rec = 0.0
+                elif year >= 2025:
+                    rec = 0.2
+                else:
+                    rec = ((year - 2020) / 5) * 0.2
+                score += rec
+                if rec:
+                    expl.append(f"recency+{rec:.2f}")
+            pub_type = row.get("PublicationType") or row.get("Publication Types")
+            if isinstance(pub_type, str) and re.search(r"review|meta-analysis", pub_type, re.I):
+                score += 0.2
+                expl.append("review")
+            dom = self._domain_boost(row["Abstract"])
+            if dom:
+                score += dom
+                expl.append(f"domain+{dom:.2f}")
+            if self._proximity(pmid, flat_terms):
+                score += 0.15
+                expl.append("proximity")
+            results.append({
+                "pmid": pmid,
+                "title": row["Title"],
+                "abstract": row["Abstract"],
+                "journal": row["Journal"],
+                "year": row["Year"],
+                "doi": row["DOI"],
+                "citation_apa": row["citation_apa"],
+                "score": float(score),
+                "cos_title": float(cos_ti[i]) if len(cos_ti) else 0.0,
+                "cos_abstract": float(cos_ab[i]) if len(cos_ab) else 0.0,
+                "matched_terms": matched,
+                "explanation": expl,
+                "abstract_len": row["Abstract_len"],
+                "has_doi": 1 if row["DOI"] else 0,
+            })
+        results.sort(key=lambda r: (-r["score"], -(r["year"] or 0), -r["abstract_len"], -r["has_doi"]))
+        return results[:k]
+
+    # -------- analytics --------
+    def facets(self, by: str) -> pd.DataFrame:
+        if by == "journal":
+            series = self.df["Journal"]
+        elif by == "year":
+            series = self.df["Year"]
+            series = series[series >= 2020]
+        elif by == "author":
+            series = self.df["Authors_list"].explode().apply(lambda x: x.split()[-1] if isinstance(x, str) else x)
+        else:
+            raise ValueError("Invalid facet")
+        counts = series.value_counts().head(20)
+        return pd.DataFrame({by: counts.index, "count": counts.values, "pct": counts.values / counts.sum() * 100})
+
+    def yearly_counts(self, pmids: List[str] | None = None) -> pd.Series:
+        df = self.df
+        if pmids is not None:
+            df = df[df["PMID"].isin(pmids)]
+        return df[df["Year"] >= 2020]["Year"].value_counts().sort_index()
+
+    def coauthor_network(self, pmids: List[str]):
+        df = self.df[self.df["PMID"].isin(pmids)]
+        G = nx.Graph()
+        for authors in df["Authors_list"]:
+            for i, a1 in enumerate(authors):
+                for a2 in authors[i + 1:]:
+                    if G.has_edge(a1, a2):
+                        G[a1][a2]["weight"] += 1
+                    else:
+                        G.add_edge(a1, a2, weight=1)
+        bet = nx.betweenness_centrality(G)
+        metrics = pd.DataFrame([{ "author": n, "degree": G.degree(n), "betweenness": bet.get(n, 0)} for n in G.nodes])
+        return G, metrics
+
+# ------------------------------- CLI ----------------------------------
+
+def parse_terms(value: str) -> List[str]:
+    if not value:
+        return []
+    parts = [p.strip().strip('"') for p in value.split(';') if p.strip()]
+    return parts
+
+def add_search_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument('--query', type=str, default='', help='terms separated by ;')
+    p.add_argument('--op', choices=['AND', 'OR', 'NOT'], default='AND')
+    p.add_argument('--fields', choices=['ti', 'ab', 'tiab'], default='tiab')
+    p.add_argument('--year-min', type=int, default=2020)
+    p.add_argument('--year-max', type=int)
+    p.add_argument('--journal-include', type=str, default='')
+    p.add_argument('--journal-exclude', type=str, default='')
+    p.add_argument('--author', type=str, default='')
+    p.add_argument('--has-doi', action='store_true')
+    p.add_argument('--exclude', type=str, default='')
+    p.add_argument('--k', type=int, default=30)
+    p.add_argument('--export-base', type=str)
+
+def run_search(engine: SearchEngine, args) -> None:
+    terms = parse_terms(args.query)
+    journal_inc = parse_terms(args.journal_include)
+    journal_exc = parse_terms(args.journal_exclude)
+    exclude = parse_terms(args.exclude)
+    results = engine.search(terms, op=args.op, fields=args.fields,
+                            year_min=args.year_min, year_max=args.year_max,
+                            journal_inc=journal_inc, journal_exc=journal_exc,
+                            author=args.author, has_doi=args.has_doi,
+                            exclude_terms=exclude, k=args.k)
+    if not results:
+        print('No results')
+        return
+    print(f"Showing {len(results)} results:\n")
+    header = f"{'rank':<4} {'score':<6} year journal pmid doi title explain"
+    print(header)
+    for i, r in enumerate(results, 1):
+        title = (r['title'][:117] + '...') if len(r['title']) > 120 else r['title']
+        explain = ','.join(r['explanation'])
+        print(f"{i:<4} {r['score']:.3f} {r['year']} {r['journal'][:20]} {r['pmid']} {r['doi'][:15]} {title} {explain}")
+    if args.export_base:
+        base = args.export_base
+        os.makedirs('outputs', exist_ok=True)
+        df = pd.DataFrame(results)
+        df.to_csv(f'outputs/{base}_results.csv', index=False)
+        with open(f'outputs/{base}_results.jsonl', 'w', encoding='utf-8') as f:
+            for rec in results:
+                f.write(json.dumps(rec, ensure_ascii=False) + '\n')
+        with open(f'outputs/{base}_citations.txt', 'w', encoding='utf-8') as f:
+            for rec in results:
+                f.write(rec['citation_apa'] + '\n')
+        print(f"Exported to outputs/{base}_results.csv/jsonl and citations.txt")
+
+
+def run_facets(engine: SearchEngine, args) -> None:
+    df = engine.facets(args.by)
+    print(df.to_string(index=False))
+
+
+def run_plot_yearly(engine: SearchEngine, args) -> None:
+    pmids = None
+    if args.filtered and args.query:
+        terms = parse_terms(args.query)
+        pmids = [r['pmid'] for r in engine.search(terms, op=args.op, fields=args.fields,
+                                                  year_min=args.year_min, year_max=args.year_max,
+                                                  journal_inc=parse_terms(args.journal_include),
+                                                  journal_exc=parse_terms(args.journal_exclude),
+                                                  author=args.author, has_doi=args.has_doi,
+                                                  exclude_terms=parse_terms(args.exclude),
+                                                  k=1000)]
+    counts = engine.yearly_counts(pmids)
+    os.makedirs('outputs', exist_ok=True)
+    plt.figure()
+    counts.sort_index().plot(kind='bar')
+    plt.ylabel('count')
+    plt.title('Yearly publications')
+    plt.tight_layout()
+    plt.savefig('outputs/yearly_counts.png')
+    print('Saved outputs/yearly_counts.png')
+
+
+def run_coauthors(engine: SearchEngine, args) -> None:
+    terms = parse_terms(args.query)
+    pmids = [r['pmid'] for r in engine.search(terms, op=args.op, fields=args.fields,
+                                              year_min=args.year_min, year_max=args.year_max,
+                                              journal_inc=parse_terms(args.journal_include),
+                                              journal_exc=parse_terms(args.journal_exclude),
+                                              author=args.author, has_doi=args.has_doi,
+                                              exclude_terms=parse_terms(args.exclude),
+                                              k=1000)]
+    if not pmids:
+        print('No data for coauthors')
+        return
+    G, metrics = engine.coauthor_network(pmids)
+    os.makedirs('outputs', exist_ok=True)
+    nx.write_gexf(G, 'outputs/coauthors.gexf')
+    metrics.to_csv('outputs/coauthors_metrics.csv', index=False)
+    print('Saved outputs/coauthors.gexf and coauthors_metrics.csv')
+
+
+def main():
+    parser = argparse.ArgumentParser(description='Local search over PubMed corpus')
+    sub = parser.add_subparsers(dest='cmd', required=True)
+    p_search = sub.add_parser('search')
+    add_search_args(p_search)
+    p_search.set_defaults(func=run_search)
+
+    p_facets = sub.add_parser('facets')
+    p_facets.add_argument('--by', choices=['journal', 'year', 'author'], required=True)
+    p_facets.set_defaults(func=run_facets)
+
+    p_plot = sub.add_parser('plot-yearly')
+    add_search_args(p_plot)
+    p_plot.add_argument('--filtered', action='store_true')
+    p_plot.set_defaults(func=run_plot_yearly)
+
+    p_co = sub.add_parser('coauthors')
+    add_search_args(p_co)
+    p_co.set_defaults(func=run_coauthors)
+
+    args = parser.parse_args()
+    df = load_corpus()
+    engine = SearchEngine(df)
+    args.func(engine, args)
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+numpy
+pandas
+scikit-learn
+matplotlib
+networkx

--- a/text_utils.py
+++ b/text_utils.py
@@ -1,0 +1,46 @@
+import re
+import unicodedata
+from typing import List
+
+GREEK_MAP = {
+    'β': 'beta',
+    'α': 'alpha',
+    'κ': 'kappa',
+    'γ': 'gamma',
+    'δ': 'delta',
+}
+
+DOMAIN_KEYWORDS = [
+    "nf-kb", "tgf-beta", "il-6", "tnf", "t cell", "epithelial barrier",
+    "autophagy", "mucosa", "tight junction", "smad2", "smad3"
+]
+
+
+def normalize_text(text: str) -> str:
+    if not isinstance(text, str):
+        return ""
+    text = unicodedata.normalize('NFKC', text)
+    for k, v in GREEK_MAP.items():
+        text = text.replace(k, v)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def tokenize(text: str) -> List[str]:
+    text = normalize_text(text).lower()
+    return re.findall(r"\b\w+\b", text)
+
+
+def expand_query_terms(terms: List[str]) -> List[List[str]]:
+    expanded = []
+    for term in terms:
+        norm = normalize_text(term).lower()
+        variants = {norm}
+        if any(tok in norm for tok in ["microrna", "mirna", "mir-"]):
+            variants.update({"microrna", "mirna", "mir"})
+        if norm in {"ibd", "inflammatory bowel disease"}:
+            variants.update({"ibd", "inflammatory bowel disease"})
+        if re.search(r"celiac|coeliac", norm):
+            variants.update({"celiac", "coeliac"})
+        expanded.append(sorted(variants))
+    return expanded


### PR DESCRIPTION
## Summary
- implement `pt_search.py` CLI to query local `papers.jsonl` corpus with filters, scoring, facets, plots and coauthor network exports
- add text utilities for normalization, greek mapping and query expansion
- document usage examples and add minimal dependencies in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: Tunnel connection failed: 403 Forbidden)*
- `python pt_search.py search --query "microRNA; IBD" --year-min 2020 --k 5` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b7071f7e4c832ba0fcf03efba5a4f3