### PR TITLE
Normalize publication type boosts and quote sanitizer

### DIFF
--- a/PubMed_API_0.1.py
+++ b/PubMed_API_0.1.py
@@ -75,9 +75,7 @@ def normalize_text(text: str) -> str:
 
 
 def sanitize_term(term: str) -> str:
-    """Escape special characters in PubMed search terms."""
-    # Escapa comillas para la consulta
-    term = term.replace('"', '\"')
+    """Wrap the term in double quotes for PubMed phrase search."""
     return f'"{term}"'
 
 def search_pmids(term, max_results, api_key, mindate="2020", maxdate="3000", sort="relevance"):


### PR DESCRIPTION
## Summary
- Normalize `PublicationTypes` to a list when loading the corpus for consistent filtering and boosting
- Boost review/meta-analysis papers by checking `PublicationTypes` regardless of input format
- Simplify `sanitize_term` to just quote search phrases

## Testing
- `python -m py_compile Proyecto-Terminal/pt_search.py Proyecto-Terminal/PubMed_API_0.1.py`
- `python pt_search.py search --query "covid" --k 1` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement numpy)*


------
https://chatgpt.com/codex/tasks/task_e_68b76f550e0c832bb4bca831d6de3420